### PR TITLE
Fixing missing suites list on matrix.

### DIFF
--- a/src/_data/results.js
+++ b/src/_data/results.js
@@ -148,6 +148,7 @@ const getSpiderResults = results => {
     result.matrices.forEach(matrix => {
       const testName = matrix.title;
       const type = matrix.columnLabel;
+      matrix.suites = matrix.suites ?? [];
       matrix.suites.forEach(suite => {
         const vendor = removeVendorNameSuffix(suite.title);
         const passed = suite.tests


### PR DESCRIPTION
The new at risk group reporting does not include a suites list, but
does use the matrix style output.
