### PR TITLE
Remove stats block.

### DIFF
--- a/src/reports/reports.md
+++ b/src/reports/reports.md
@@ -13,14 +13,6 @@ breadcrumbs:
     details: report.respecConfig
     showLinks: true %}
 
-<div class="ui right floated card">
-  <pre class="content">
-    {%- for stat in report.stats %}
-    {{ stat }}
-    {%- endfor -%}
-  </pre>
-</div>
-
 <div class="ui bulleted list">
 {%- for matrix in report.matrices -%}
   <div class="item">


### PR DESCRIPTION
The stats are hard to parse as they currently aggregate passes/fails
accross all implementations...and so do not show the actual state of
the specification report.
