### PR TITLE
Remove At Risk sections.

### DIFF
--- a/src/_data/results.js
+++ b/src/_data/results.js
@@ -192,17 +192,18 @@ function removeVendorNameSuffix(vendorName) {
 
 /**
  * Removes the "interop" matrices because they have no "suites" (columns)
- * and their rows are structured differently than all other matrices.
+ * and their rows are structured differently than all other matrices. Also
+ * removes "at risk" sections which are W3C process specific.
  *
  * @param {Array} results - Results from urls.
  * @returns {Array} Results without interop matrices.
  */
-function removeInteropTestResults(results) {
+function removeSomeTestSections(results) {
   const curatedResults = results.map(result => ({
     ...result,
     matrices: result.matrices.filter(matrix => {
       const testName = matrix.title.toLowerCase();
-      return !testName.includes('interop');
+      return !testName.includes('interop') && !testName.includes('at risk');
     })
   }));
   return curatedResults;
@@ -228,8 +229,8 @@ module.exports = async function() {
     return result.status !== 'fulfilled' ? all : [...all, result.value];
   }, []);
 
-  /* Temporarily remove interop matrices */
-  results = removeInteropTestResults(results);
+  /* Temporarily remove interop and at risk matrices */
+  results = removeSomeTestSections(results);
 
   return {
     all: results,


### PR DESCRIPTION
These sections are W3C process specific and confusing in the context
of canivc.com. This change was added alongside the interop section
removal.

Fixes #42.
