### PR TITLE
Add groups info; add conf buttons to imp pages.

### DIFF
--- a/src/_data/results.js
+++ b/src/_data/results.js
@@ -222,11 +222,13 @@ function implementersOfSpecs(results) {
   results.forEach(result => {
     const specTitle = result.respecConfig?.title || result.title || '';
     const specShort = result.respecConfig?.shortName || '';
+    const specGroup = result.respecConfig?.group;
     (result.matrices || []).forEach(matrix => {
       (matrix.suites || []).forEach(suite => {
         const vendor = removeNameSuffix(suite.title);
         if(!map[vendor]) {
           map[vendor] = {
+            groups: new Set(),
             specs: [],
             totals: {passed: 0, failed: 0, pending: 0, total: 0}
           };
@@ -241,9 +243,11 @@ function implementersOfSpecs(results) {
           specEntry = {
             title: specTitle,
             shortName: specShort,
+            group: specGroup,
             stats: {passed: 0, failed: 0, pending: 0, total: 0}
           };
           map[vendor].specs.push(specEntry);
+          map[vendor].groups.add(specGroup);
         }
 
         // aggregate counts from this suite into the spec entry
@@ -269,6 +273,8 @@ function implementersOfSpecs(results) {
   });
   Object.values(map).forEach(v => {
     v.specs.sort((a, b) => a.title.localeCompare(b.title));
+    // turn groups into an array for JSON serialization
+    v.groups = Array.from(v.groups).sort();
   });
   return map;
 }

--- a/src/implementations/implementations.md
+++ b/src/implementations/implementations.md
@@ -12,7 +12,19 @@ eleventyComputed:
 {% assign info = implementations[vendor] %}
 {% assign testCategories = results.testsByCompany[vendor] %}
 
-<h1 style="text-align: center">{{ vendor }}</h1>
+<h1 class="ui centered header" style="padding-left: 2.5em">
+  {{ vendor }}
+  <div class="ui simple right floated icon dropdown button">
+    <i class="cogs icon"></i>
+    <div class="left menu">
+      {%- for group in results.implementersOfSpecs[vendor].groups reversed -%}
+      <a class="item" href="https://github.com/{{ group }}/vc-test-suite-implementations/blob/main/implementations/{{ vendor | replace: ', Inc.', '' | replace: ' ', '' }}.json" target="_blank" rel="noopener">
+        {{ group }}
+      </a>
+      {%- endfor -%}
+    </div>
+  </div>
+</h1>
 
 <div class="ui very padded segment">
   <!-- Spider Chart -->


### PR DESCRIPTION
Fixes #31.

See the top right corner on any implementation page. For example:
https://add-config-buttons.canivc.pages.dev/implementations/digital-bazaar-inc/